### PR TITLE
Fixed bullets not being given if victim has 0 lives

### DIFF
--- a/addons/sourcemod/scripting/specialdays/one_in_chamber.sp
+++ b/addons/sourcemod/scripting/specialdays/one_in_chamber.sp
@@ -45,17 +45,7 @@ public void OneInChamber_OnPlayerDeath(Event event, const char[] name, bool dont
 
     g_playerLives[victim]--;
 
-    if (g_playerLives[victim] <= 0)
-    {
-        PrintToChat(victim, "%s You are out of lives", g_SDPrefix);
-        return;
-    }
-
-    if (StrContains(weapon, "knife") != -1)
-    {
-        AddToClip(attacker, 1);
-    }
-    else if (StrContains(weapon, "usp") != -1)
+    if (StrContains(weapon, "knife") || StrContains(weapon, "usp"))
     {
         AddToClip(attacker, 1);
     }
@@ -64,6 +54,12 @@ public void OneInChamber_OnPlayerDeath(Event event, const char[] name, bool dont
     {
         PrintToChatAll("%s %N won the Special Day!", g_SDPrefix, attacker);
         CS_TerminateRound(5.0, CSRoundEnd_Draw, true);
+        return;
+    }
+
+    if (g_playerLives[victim] <= 0)
+    {
+        PrintToChat(victim, "%s You are out of lives", g_SDPrefix);
         return;
     }
 
@@ -81,7 +77,7 @@ public Action OneInChamber_OnTakeDamage(int victim, int &attacker, int &inflicto
     char weapon[32];
     GetClientWeapon(attacker, weapon, sizeof(weapon));
 
-    if ((StrContains(weapon, "knife") != -1)||(StrContains(weapon, "usp") != -1))
+    if (StrContains(weapon, "knife") || StrContains(weapon, "usp"))
     { 
         int weaponvictim = GetPlayerWeaponSlot(victim, CS_SLOT_SECONDARY);
 

--- a/addons/sourcemod/scripting/specialdays/one_in_chamber.sp
+++ b/addons/sourcemod/scripting/specialdays/one_in_chamber.sp
@@ -43,7 +43,6 @@ public void OneInChamber_OnPlayerDeath(Event event, const char[] name, bool dont
     int attacker = GetClientOfUserId(event.GetInt("attacker"));
     int victim = GetClientOfUserId(event.GetInt("userid"));
     event.GetString("weapon", weapon, sizeof(weapon));
-    PrintToChatAll("Victim: %N Attacker: %N", victim, attacker);
 
     g_playerLives[victim]--;
     if (StrContains(weapon, "knife") || StrContains(weapon, "usp"))

--- a/addons/sourcemod/scripting/specialdays/one_in_chamber.sp
+++ b/addons/sourcemod/scripting/specialdays/one_in_chamber.sp
@@ -23,6 +23,7 @@ public void SpecialDay_OneInChamber_Begin()
 
     for (int i = 1; i <= MaxClients; i++)
     {
+        g_playerLives[i] = 3;
         if (!IsValidClient(i) || !IsPlayerAlive(i))
             continue; 
 
@@ -42,29 +43,35 @@ public void OneInChamber_OnPlayerDeath(Event event, const char[] name, bool dont
     int attacker = GetClientOfUserId(event.GetInt("attacker"));
     int victim = GetClientOfUserId(event.GetInt("userid"));
     event.GetString("weapon", weapon, sizeof(weapon));
+    PrintToChatAll("Victim: %N Attacker: %N", victim, attacker);
 
     g_playerLives[victim]--;
-
     if (StrContains(weapon, "knife") || StrContains(weapon, "usp"))
     {
-        AddToClip(attacker, 1);
+        if (IsValidClient(attacker))
+        {
+            //In the case of a slay
+            if(IsPlayerAlive(attacker))
+            {
+                AddToClip(attacker, 1);
+            }
+        }
     }
-
     if (GetNumAlivePlayers() == 1)
     {
         PrintToChatAll("%s %N won the Special Day!", g_SDPrefix, attacker);
         CS_TerminateRound(5.0, CSRoundEnd_Draw, true);
         return;
     }
-
     if (g_playerLives[victim] <= 0)
     {
         PrintToChat(victim, "%s You are out of lives", g_SDPrefix);
-        return;
     }
-
-    CreateTimer(1.0, Timer_OneInChamber_Revive, victim);
-    PrintToChat(victim, "%s You have %i live(s) left", g_SDPrefix, g_playerLives[victim]);
+    else
+    {
+        CreateTimer(1.0, Timer_OneInChamber_Revive, victim);
+        PrintToChat(victim, "%s You have %i live(s) left", g_SDPrefix, g_playerLives[victim]);
+    }
 }
 
 public Action OneInChamber_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)


### PR DESCRIPTION
Previously if the victim had 0 lives it would return the statement preventing the function that gives the bullet from being called leaving people without a bullet. This was fixed by just moving that statement containing the return statement to the bottom of the on-death function. There is also some code cleanup like removing `!= -1` in if statements.